### PR TITLE
Addition of Usage-Monitoring-Report and Usage-Monitoring-Support AVPs

### DIFF
--- a/diam/avp/codes.go
+++ b/diam/avp/codes.go
@@ -695,6 +695,8 @@ const (
 	UnitValue                                  = 445
 	UsageMonitoringInformation                 = 1067
 	UsageMonitoringLevel                       = 1068
+	UsageMonitoringReport                      = 1069
+	UsageMonitoringSupport                     = 1070
 	UsedServiceUnit                            = 446
 	UserCSGInformation                         = 2319
 	UserData                                   = 606

--- a/diam/dict/default.go
+++ b/diam/dict/default.go
@@ -1335,6 +1335,8 @@ var gxcreditcontrolXML = `<?xml version="1.0" encoding="UTF-8"?>
                 <rule avp="Granted-Service-Unit" required="false" max="2"/>
                 <rule avp="Used-Service-Unit" required="false" max="2"/>
                 <rule avp="Usage-Monitoring-Level" required="false" max="1"/>
+                <rule avp="Usage-Monitoring-Report" required="false" max="0"/>
+                <rule avp="Usage-Monitoring-Support" required="false" max="0"/>
             </data>
         </avp>
 
@@ -1343,6 +1345,20 @@ var gxcreditcontrolXML = `<?xml version="1.0" encoding="UTF-8"?>
             <data type="Enumerated">
                 <item code="0" name="SESSION_LEVEL"/>
                 <item code="1" name="PCC_RULE_LEVEL"/>
+            </data>
+        </avp>
+
+        <avp name="Usage-Monitoring-Report" code="1069" must="V" may="P" must-not="M" may-encrypt="y" vendor-id="10415">
+            <!-- 3GPP 29.212 -->
+            <data type="Enumerated">
+                <item code="0" name="USAGE_MONITORING_REPORT"/>
+            </data>
+        </avp>
+
+        <avp name="Usage-Monitoring-Support" code="1070" must="V" may="P" must-not="M" may-encrypt="y" vendor-id="10415">
+            <!-- 3GPP 29.212 -->
+            <data type="Enumerated">
+                <item code="0" name="USAGE_MONITORING_SUPPORT"/>
             </data>
         </avp>
 

--- a/diam/dict/testdata/gx_credit_control.xml
+++ b/diam/dict/testdata/gx_credit_control.xml
@@ -262,6 +262,8 @@
                 <rule avp="Granted-Service-Unit" required="false" max="2"/>
                 <rule avp="Used-Service-Unit" required="false" max="2"/>
                 <rule avp="Usage-Monitoring-Level" required="false" max="1"/>
+                <rule avp="Usage-Monitoring-Report" required="false" max="0"/>
+                <rule avp="Usage-Monitoring-Support" required="false" max="0"/>
             </data>
         </avp>
 
@@ -270,6 +272,20 @@
             <data type="Enumerated">
                 <item code="0" name="SESSION_LEVEL"/>
                 <item code="1" name="PCC_RULE_LEVEL"/>
+            </data>
+        </avp>
+
+        <avp name="Usage-Monitoring-Report" code="1069" must="V" may="P" must-not="M" may-encrypt="y" vendor-id="10415">
+            <!-- 3GPP 29.212 -->
+            <data type="Enumerated">
+                <item code="0" name="USAGE_MONITORING_REPORT"/>
+            </data>
+        </avp>
+
+        <avp name="Usage-Monitoring-Support" code="1070" must="V" may="P" must-not="M" may-encrypt="y" vendor-id="10415">
+            <!-- 3GPP 29.212 -->
+            <data type="Enumerated">
+                <item code="0" name="USAGE_MONITORING_SUPPORT"/>
             </data>
         </avp>
 


### PR DESCRIPTION
## Sumary

Attempt to add `Usage-Monitoring-Report` and `Usage-Monitoring-Support` AVPs on `Usage-Monitoring-Information`

https://www.developingsolutions.com/DiaDict/Dictionary/Usage-Monitoring-Information.html

To create this PR
- edit `diam/dict/testdata/gx_credit_control.xml`
- go to `docker` folder and `docker-compose exec go-diameter bash`
- From docker run `go-diameter/diam/autogen.sh`
- run `/go/go-diameter# go test ./...`


## Test
```
root@docker-desktop:/go/go-diameter# go test ./...
ok  	github.com/fiorix/go-diameter/v4/diam	0.535s
?   	github.com/fiorix/go-diameter/v4/diam/avp	[no test files]
ok  	github.com/fiorix/go-diameter/v4/diam/datatype	(cached)
ok  	github.com/fiorix/go-diameter/v4/diam/diamtest	0.111s
ok  	github.com/fiorix/go-diameter/v4/diam/dict	0.466s
ok  	github.com/fiorix/go-diameter/v4/diam/sm	2.722s
ok  	github.com/fiorix/go-diameter/v4/diam/sm/smparser	0.090s
ok  	github.com/fiorix/go-diameter/v4/diam/sm/smpeer	0.077s
?   	github.com/fiorix/go-diameter/v4/examples/bare	[no test files]
?   	github.com/fiorix/go-diameter/v4/examples/client	[no test files]
?   	github.com/fiorix/go-diameter/v4/examples/client/diameter_sy	[no test files]
?   	github.com/fiorix/go-diameter/v4/examples/diam_sctp_client	[no test files]
?   	github.com/fiorix/go-diameter/v4/examples/grouped	[no test files]
?   	github.com/fiorix/go-diameter/v4/examples/s6a_client	[no test files]
?   	github.com/fiorix/go-diameter/v4/examples/s6a_proxy/protos	[no test files]
?   	github.com/fiorix/go-diameter/v4/examples/s6a_proxy/service	[no test files]
ok  	github.com/fiorix/go-diameter/v4/examples/s6a_proxy/service/test	0.533s
?   	github.com/fiorix/go-diameter/v4/examples/s6a_server	[no test files]
?   	github.com/fiorix/go-diameter/v4/examples/server	[no test files]
?   	github.com/fiorix/go-diameter/v4/examples/snoop	[no test files]
?   	github.com/fiorix/go-diameter/v4/examples/wireshark-dict-tool	[no test files]
```

Signed-off-by: Oriol Batalla <obatalla@fb.com>